### PR TITLE
UP-2007 Refactoring request id first round

### DIFF
--- a/src/main/scala/com/ubirch/messagesigner/MessageSignerMicroservice.scala
+++ b/src/main/scala/com/ubirch/messagesigner/MessageSignerMicroservice.scala
@@ -20,9 +20,9 @@ class MessageSignerMicroservice(
 
     val algorithm = record.findHeader("algorithm").getOrElse("unknown")
     val maybeCurve = MessageSignerMicroservice.curveFromString(algorithm)
+    val requestId = record.requestIdHeader().orNull
 
-    logger.info(s"signing response: ${record.value().ubirchPacket} algorithm=[$algorithm] | curve=[${maybeCurve.map(_.name()).getOrElse("No curve")}]",
-      v("requestId", record.key()))
+    logger.info(s"signing response: ${record.value().ubirchPacket} algorithm=[$algorithm] | curve=[${maybeCurve.map(_.name()).getOrElse("No curve")}]", v("requestId", requestId))
 
     val maybeSigner = for {
       curve <- maybeCurve

--- a/src/main/scala/com/ubirch/messagesigner/Signer.scala
+++ b/src/main/scala/com/ubirch/messagesigner/Signer.scala
@@ -33,9 +33,10 @@ class Signer(_privateKey: => PrivKey) extends StrictLogging {
 
   def sign(record: ConsumerRecord[String, MessageEnvelope]): ConsumerRecord[String, StringOrByteArray] = {
     val payload = record.value().ubirchPacket
+    val requestId = record.requestIdHeader().orNull
     val (encoded, newContentType) = record.findHeader("Content-Type") match {
-      case Some(ct@"application/json") => (StringOrByteArray(signAndEncodeJson(payload, record.key())), ct)
-      case _ => (StringOrByteArray(signAndEncodeMsgPack(payload, record.key())), "application/octet-stream")
+      case Some(ct@"application/json") => (StringOrByteArray(signAndEncodeJson(payload, requestId)), ct)
+      case _ => (StringOrByteArray(signAndEncodeMsgPack(payload, requestId)), "application/octet-stream")
     }
 
     record.copy(value = encoded).withExtraHeaders("Content-Type" -> newContentType)


### PR DESCRIPTION
Using the request id as part of the key field for a producer record values makes the partitioning of the data to be unbalanced. This PR moves the request id from the key to a header in the record.