### PR TITLE
UP-2014 Adding eager start config key to allow fast fail

### DIFF
--- a/src/main/resources/application-base.conf
+++ b/src/main/resources/application-base.conf
@@ -1,4 +1,7 @@
 niomon-signer {
+
+  eagerStart = true
+
   health-check {
     enabled = true
     port = 8888


### PR DESCRIPTION
When invalid priv keys has been set or are missing the error is only thrown when the first message arrives. It should fail earlier as the deployment won’t fail.