### PR TITLE
Feature/up 1885 bytes payload

### DIFF
--- a/src/main/java/com/ubirch/protocol/codec/MsgPackProtocolEncoderExtended.java
+++ b/src/main/java/com/ubirch/protocol/codec/MsgPackProtocolEncoderExtended.java
@@ -19,7 +19,7 @@ public class MsgPackProtocolEncoderExtended extends MsgPackProtocolEncoder {
     final private MsgPackProtocolSigning protocolSigning = new MsgPackProtocolSigning() {
         @Override
         public void payloadConsumer(MessagePacker packer, ProtocolMessage pm, ByteArrayOutputStream out) throws IOException {
-            // To be able to return the payload a just bytes and not as base64 values, we have to
+            // To be able to return the payload as just bytes and not as base64 values, we have to
             // explicitly try to decode and pack the data in the msgpack.
             // There seems to be a limitation with the way json4s handles binary nodes.
             // https://gitlab.com/ubirch/ubirch-kafka-envelope/-/blob/master/src/main/scala/com/ubirch/kafka/package.scala#L166
@@ -27,7 +27,7 @@ public class MsgPackProtocolEncoderExtended extends MsgPackProtocolEncoder {
                 // write the payload
                 try {
                     byte[] bytes = Base64.getDecoder().decode(pm.getPayload().asText());
-                    packer.packBinaryHeader(16).addPayload(bytes);
+                    packer.packBinaryHeader(bytes.length).addPayload(bytes);
                 } catch (Exception e) {
                     super.payloadConsumer(packer, pm, out);
                 }

--- a/src/main/java/com/ubirch/protocol/codec/MsgPackProtocolEncoderExtended.java
+++ b/src/main/java/com/ubirch/protocol/codec/MsgPackProtocolEncoderExtended.java
@@ -19,10 +19,13 @@ public class MsgPackProtocolEncoderExtended extends MsgPackProtocolEncoder {
     final private MsgPackProtocolSigning protocolSigning = new MsgPackProtocolSigning() {
         @Override
         public void payloadConsumer(MessagePacker packer, ProtocolMessage pm, ByteArrayOutputStream out) throws IOException {
+            // To be able to return the payload a just bytes and not as base64 values, we have to
+            // explicitly try to decode and pack the data in the msgpack.
+            // There seems to be a limitation with the way json4s handles binary nodes.
+            // https://gitlab.com/ubirch/ubirch-kafka-envelope/-/blob/master/src/main/scala/com/ubirch/kafka/package.scala#L166
             if (pm.getPayload() instanceof TextNode) {
                 // write the payload
                 try {
-                    //We try to decode from base64 as this is what is expected when it is binary
                     byte[] bytes = Base64.getDecoder().decode(pm.getPayload().asText());
                     packer.packBinaryHeader(16).addPayload(bytes);
                 } catch (Exception e) {

--- a/src/main/java/com/ubirch/protocol/codec/MsgPackProtocolEncoderExtended.java
+++ b/src/main/java/com/ubirch/protocol/codec/MsgPackProtocolEncoderExtended.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2019 ubirch GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ubirch.protocol.codec;
+
+import com.fasterxml.jackson.databind.node.TextNode;
+import com.ubirch.protocol.ProtocolException;
+import com.ubirch.protocol.ProtocolMessage;
+import com.ubirch.protocol.ProtocolSigner;
+
+import java.io.IOException;
+import java.security.InvalidKeyException;
+import java.security.SignatureException;
+import java.util.Base64;
+
+public class MsgPackProtocolEncoderExtended extends MsgPackProtocolEncoder {
+
+    private static final MsgPackProtocolEncoderExtended instance = new MsgPackProtocolEncoderExtended();
+
+    public static MsgPackProtocolEncoderExtended getEncoder() {
+        return instance;
+    }
+
+    @Override
+    public byte[] encode(ProtocolMessage pm, ProtocolSigner signer) throws ProtocolException, SignatureException {
+        if (pm == null || signer == null) {
+            throw new IllegalArgumentException("message or signer null");
+        }
+
+        try {
+            MsgPackProtocolSigning protocolSigning = new MsgPackProtocolSigning(pm, signer) {
+                @Override
+                public void payload() throws IOException {
+                    if (pm.getPayload() instanceof TextNode) {
+                        // write the payload
+                        byte[] bytes = Base64.getDecoder().decode(pm.getPayload().asText());
+                        packer.packBinaryHeader(16).addPayload(bytes);
+                    } else {
+                        super.payload();
+                    }
+                }
+            };
+            return encode(protocolSigning.sign());
+        } catch (InvalidKeyException e) {
+            throw new ProtocolException("invalid key", e);
+        } catch (IOException e) {
+            throw new ProtocolException("msgpack encoding failed", e);
+        } catch (NullPointerException e) {
+            throw new ProtocolException("msgpack encoding failed: field null?", e);
+        }
+    }
+
+}

--- a/src/main/java/com/ubirch/protocol/codec/MsgPackProtocolEncoderExtended.java
+++ b/src/main/java/com/ubirch/protocol/codec/MsgPackProtocolEncoderExtended.java
@@ -1,26 +1,12 @@
-/*
- * Copyright (c) 2019 ubirch GmbH
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package com.ubirch.protocol.codec;
 
 import com.fasterxml.jackson.databind.node.TextNode;
 import com.ubirch.protocol.ProtocolException;
 import com.ubirch.protocol.ProtocolMessage;
 import com.ubirch.protocol.ProtocolSigner;
+import org.msgpack.core.MessagePacker;
 
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.security.InvalidKeyException;
 import java.security.SignatureException;
@@ -29,6 +15,19 @@ import java.util.Base64;
 public class MsgPackProtocolEncoderExtended extends MsgPackProtocolEncoder {
 
     private static final MsgPackProtocolEncoderExtended instance = new MsgPackProtocolEncoderExtended();
+
+    final private MsgPackProtocolSigning protocolSigning = new MsgPackProtocolSigning() {
+        @Override
+        public void payloadConsumer(MessagePacker packer, ProtocolMessage pm, ByteArrayOutputStream out) throws IOException {
+            if (pm.getPayload() instanceof TextNode) {
+                // write the payload
+                byte[] bytes = Base64.getDecoder().decode(pm.getPayload().asText());
+                packer.packBinaryHeader(16).addPayload(bytes);
+            } else {
+                super.payloadConsumer(packer, pm, out);
+            }
+        }
+    };
 
     public static MsgPackProtocolEncoderExtended getEncoder() {
         return instance;
@@ -41,19 +40,7 @@ public class MsgPackProtocolEncoderExtended extends MsgPackProtocolEncoder {
         }
 
         try {
-            MsgPackProtocolSigning protocolSigning = new MsgPackProtocolSigning(pm, signer) {
-                @Override
-                public void payload() throws IOException {
-                    if (pm.getPayload() instanceof TextNode) {
-                        // write the payload
-                        byte[] bytes = Base64.getDecoder().decode(pm.getPayload().asText());
-                        packer.packBinaryHeader(16).addPayload(bytes);
-                    } else {
-                        super.payload();
-                    }
-                }
-            };
-            return encode(protocolSigning.sign());
+            return encode(protocolSigning.sign(pm, signer));
         } catch (InvalidKeyException e) {
             throw new ProtocolException("invalid key", e);
         } catch (IOException e) {

--- a/src/main/java/com/ubirch/protocol/codec/MsgPackProtocolEncoderExtended.java
+++ b/src/main/java/com/ubirch/protocol/codec/MsgPackProtocolEncoderExtended.java
@@ -21,8 +21,13 @@ public class MsgPackProtocolEncoderExtended extends MsgPackProtocolEncoder {
         public void payloadConsumer(MessagePacker packer, ProtocolMessage pm, ByteArrayOutputStream out) throws IOException {
             if (pm.getPayload() instanceof TextNode) {
                 // write the payload
-                byte[] bytes = Base64.getDecoder().decode(pm.getPayload().asText());
-                packer.packBinaryHeader(16).addPayload(bytes);
+                try {
+                    //We try to decode from base64 as this is what is expected when it is binary
+                    byte[] bytes = Base64.getDecoder().decode(pm.getPayload().asText());
+                    packer.packBinaryHeader(16).addPayload(bytes);
+                } catch (Exception e) {
+                    super.payloadConsumer(packer, pm, out);
+                }
             } else {
                 super.payloadConsumer(packer, pm, out);
             }

--- a/src/main/java/com/ubirch/protocol/codec/MsgPackProtocolSigning.java
+++ b/src/main/java/com/ubirch/protocol/codec/MsgPackProtocolSigning.java
@@ -12,8 +12,6 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.security.InvalidKeyException;
 import java.security.SignatureException;
-import java.util.function.BiFunction;
-import java.util.function.Function;
 
 public class MsgPackProtocolSigning {
 

--- a/src/main/java/com/ubirch/protocol/codec/MsgPackProtocolSigning.java
+++ b/src/main/java/com/ubirch/protocol/codec/MsgPackProtocolSigning.java
@@ -12,6 +12,8 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.security.InvalidKeyException;
 import java.security.SignatureException;
+import java.util.function.BiFunction;
+import java.util.function.Function;
 
 public class MsgPackProtocolSigning {
 

--- a/src/main/java/com/ubirch/protocol/codec/MsgPackProtocolSigning.java
+++ b/src/main/java/com/ubirch/protocol/codec/MsgPackProtocolSigning.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2019 ubirch GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ubirch.protocol.codec;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.ubirch.protocol.ProtocolException;
+import com.ubirch.protocol.ProtocolMessage;
+import com.ubirch.protocol.ProtocolSigner;
+import org.msgpack.core.MessagePack;
+import org.msgpack.core.MessagePacker;
+import org.msgpack.jackson.dataformat.MessagePackFactory;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.security.InvalidKeyException;
+import java.security.SignatureException;
+
+public class MsgPackProtocolSigning {
+
+    private static MessagePack.PackerConfig config = new MessagePack.PackerConfig().withStr8FormatSupport(false);
+
+    final ByteArrayOutputStream out;
+    final MessagePacker packer;
+    final ProtocolMessage pm;
+    final ProtocolSigner signer;
+
+    public MsgPackProtocolSigning(ProtocolMessage pm, ProtocolSigner signer) {
+        this.pm = pm;
+        this.signer = signer;
+        this.out = new ByteArrayOutputStream(255);
+        this.packer = config.newPacker(out);
+    }
+
+    public void version() throws IOException {
+        packer.packInt(pm.getVersion());
+    }
+
+    public void UUID() throws IOException {
+        packer.packBinaryHeader(16).addPayload(UUIDUtil.uuidToBytes(pm.getUUID()));
+    }
+
+    public void chain() throws IOException {
+        switch (pm.getVersion()) {
+            case ProtocolMessage.CHAINED:
+                packer.packBinaryHeader(64);
+                byte[] chainSignature = pm.getChain();
+                if (chainSignature == null) {
+                    packer.addPayload(new byte[64]);
+                } else {
+                    packer.addPayload(chainSignature);
+                }
+                break;
+            case ProtocolMessage.SIGNED:
+                break;
+            default:
+                throw new ProtocolException(String.format("unknown protocol version: 0x%x", pm.getVersion()));
+        }
+    }
+
+    public void hint() throws IOException {
+        packer.packInt(pm.getHint());
+    }
+
+    public void payload() throws IOException {
+        ObjectMapper mapper = new ObjectMapper(new MessagePackFactory());
+        mapper.writeValue(out, pm.getPayload());
+    }
+
+    public ProtocolMessage sign() throws IOException, SignatureException, InvalidKeyException {
+        packer.packArrayHeader(5 + (pm.getVersion() & 0x0f) - 2);
+        version();
+        UUID();
+        chain();
+        hint();
+        packer.flush(); // make sure everything is in the byte buffer
+        payload();
+        packer.close(); // also closes out
+
+        byte[] dataToSign = out.toByteArray();
+        byte[] signature = signer.sign(pm.getUUID(), dataToSign, 0, dataToSign.length);
+        pm.setSigned(dataToSign);
+        pm.setSignature(signature);
+        return pm;
+    }
+
+}

--- a/src/main/scala/com/ubirch/messagesigner/Signer.scala
+++ b/src/main/scala/com/ubirch/messagesigner/Signer.scala
@@ -21,7 +21,7 @@ import com.ubirch.client.protocol.DefaultProtocolSigner
 import com.ubirch.crypto.PrivKey
 import com.ubirch.kafka.{MessageEnvelope, _}
 import com.ubirch.messagesigner.StringOrByteArray.StringOrByteArray
-import com.ubirch.protocol.codec.{JSONProtocolEncoder, MsgPackProtocolEncoder}
+import com.ubirch.protocol.codec.{JSONProtocolEncoder, MsgPackProtocolEncoderExtended}
 import com.ubirch.protocol.{ProtocolMessage, ProtocolSigner}
 import net.logstash.logback.argument.StructuredArguments.v
 import org.apache.kafka.clients.consumer.ConsumerRecord
@@ -48,7 +48,7 @@ class Signer(_privateKey: => PrivKey) extends StrictLogging {
   }
 
   private def signAndEncodeMsgPack(payload: ProtocolMessage, id: String): Array[Byte] = {
-    logger.debug("encoding with MsgPackProtocolEncoder", v("requestId", id))
-    MsgPackProtocolEncoder.getEncoder.encode(payload, signer)
+    logger.info("encoding with MsgPackProtocolEncoderExtended", v("requestId", id))
+    MsgPackProtocolEncoderExtended.getEncoder.encode(payload, signer)
   }
 }


### PR DESCRIPTION
When a BinaryNode is used as the payload for the Protocol Message, a limitation in the way json4s supports these types of nodes, makes that the payload actually be a base64-encoded value, like the following piece of data taken from tests performed.

![image](https://user-images.githubusercontent.com/12374552/91995288-ea69ae00-ed37-11ea-8547-978ee43f9f99.png)

After introduction the solution, shown below, the response looks like this now:

![image](https://user-images.githubusercontent.com/12374552/91995321-f6ee0680-ed37-11ea-81e2-6f37956b1ce2.png)

Note that the example don't correspond to the same UPP.

